### PR TITLE
feat: add dark mode with theme toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,12 @@
   body {
     background-color: #faf6f0;
     color: #3c3632;
+    transition: background-color 0.2s, color 0.2s;
+  }
+
+  .dark body {
+    background-color: #1a1614;
+    color: #e8e0d8;
   }
 
   input,
@@ -13,8 +19,18 @@
     @apply border border-parchment-300 bg-parchment-50 text-ink rounded-xl px-4 py-2.5 w-full outline-none transition-all duration-200 placeholder:text-ink-faint;
   }
 
+  .dark input,
+  .dark textarea {
+    @apply border-night-border bg-night-surface text-night-text placeholder:text-night-muted;
+  }
+
   input:focus,
   textarea:focus {
     @apply border-amber-400 ring-2 ring-amber-100 bg-white;
+  }
+
+  .dark input:focus,
+  .dark textarea:focus {
+    @apply border-amber-500 ring-2 ring-amber-500/20 bg-night-card;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,15 +18,20 @@ export default function RootLayout({
 }) {
   return (
     <html suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("theme");if(t==="dark"||(!t&&window.matchMedia("(prefers-color-scheme:dark)").matches)){document.documentElement.classList.add("dark")}}catch(e){}})()`,
+          }}
+        />
+      </head>
       <body className={nunito.className}>
         <Navbar />
         <main>{children}</main>
         <Toaster
           toastOptions={{
+            className: "!bg-parchment-50 !border-parchment-300 !text-ink dark:!bg-night-card dark:!border-night-border dark:!text-night-text",
             style: {
-              background: "#fff8f0",
-              border: "1px solid #ebe0cc",
-              color: "#3c3632",
               borderRadius: "14px",
             },
           }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,16 +17,16 @@ export default async function Home() {
         {tasks.length === 0 ? (
           <div className="flex items-center justify-center h-[70vh]">
             <div className="text-center">
-              <BiTaskX className="mx-auto text-[10rem] text-parchment-400" />
-              <h1 className="text-2xl font-bold my-4 text-ink">
+              <BiTaskX className="mx-auto text-[10rem] text-parchment-400 dark:text-night-faint" />
+              <h1 className="text-2xl font-bold my-4 text-ink dark:text-night-text">
                 No tasks yet
               </h1>
-              <p className="text-ink-muted mb-6">
+              <p className="text-ink-muted dark:text-night-muted mb-6">
                 Start by creating your first task
               </p>
               <a
                 href="/tasks/new"
-                className="inline-block px-6 py-3 bg-amber-500 text-white font-semibold rounded-xl hover:bg-amber-600 shadow-card hover:shadow-card-hover transition-all duration-200"
+                className="inline-block px-6 py-3 bg-amber-500 text-white font-semibold rounded-xl hover:bg-amber-600 shadow-card dark:shadow-card-dark hover:shadow-card-hover dark:hover:shadow-card-dark-hover transition-all duration-200"
               >
                 Create one
               </a>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,22 +1,26 @@
 import Link from "next/link";
+import { ThemeToggle } from "./ThemeToggle";
 
 export const Navbar = () => {
   return (
-    <nav className="bg-parchment-100 border-b border-parchment-300">
+    <nav className="bg-parchment-100 border-b border-parchment-300 dark:bg-night-surface dark:border-night-border transition-colors duration-200">
       <div className="container mx-auto flex items-center justify-between px-6 py-4">
         <Link href="/" className="flex items-center gap-2.5">
           <span className="text-2xl">📓</span>
-          <span className="font-extrabold text-lg text-ink tracking-tight">
+          <span className="font-extrabold text-lg text-ink dark:text-night-text tracking-tight">
             My Tasks
           </span>
         </Link>
 
-        <Link
-          href="/tasks/new"
-          className="bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-white font-semibold py-2 px-5 rounded-xl shadow-card hover:shadow-card-hover transition-all duration-200"
-        >
-          + New Task
-        </Link>
+        <div className="flex items-center gap-3">
+          <ThemeToggle />
+          <Link
+            href="/tasks/new"
+            className="bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-white font-semibold py-2 px-5 rounded-xl shadow-card dark:shadow-card-dark hover:shadow-card-hover dark:hover:shadow-card-dark-hover transition-all duration-200"
+          >
+            + New Task
+          </Link>
+        </div>
       </div>
     </nav>
   );

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const ThemeToggle = () => {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    setDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  const toggle = () => {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label="Toggle theme"
+      className="w-9 h-9 flex items-center justify-center rounded-xl bg-parchment-200 hover:bg-parchment-300 dark:bg-night-card dark:hover:bg-night-border transition-colors duration-200 text-lg"
+    >
+      {dark ? "☀️" : "🌙"}
+    </button>
+  );
+};

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -9,21 +9,21 @@ export const TaskCard = ({ task }: Props) => {
   return (
     <Link
       href={`/tasks/edit/${task.id}`}
-      className="group block bg-white border border-parchment-200 rounded-notebook p-5 shadow-card hover:shadow-card-hover hover:border-parchment-300 transition-all duration-200"
+      className="group block bg-white border border-parchment-200 rounded-notebook p-5 shadow-card hover:shadow-card-hover hover:border-parchment-300 dark:bg-night-card dark:border-night-border dark:shadow-card-dark dark:hover:shadow-card-dark-hover dark:hover:border-night-muted transition-all duration-200"
     >
       <div className="flex items-start justify-between gap-3">
-        <h3 className="text-base font-bold text-ink group-hover:text-amber-700 transition-colors duration-200">
+        <h3 className="text-base font-bold text-ink dark:text-night-text group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors duration-200">
           {task.title}
         </h3>
         <span className="shrink-0 w-2 h-2 mt-2 rounded-full bg-amber-400 opacity-60 group-hover:opacity-100 transition-opacity" />
       </div>
       {task.description && (
-        <p className="text-sm text-ink-light mt-2 leading-relaxed line-clamp-2">
+        <p className="text-sm text-ink-light dark:text-night-muted mt-2 leading-relaxed line-clamp-2">
           {task.description}
         </p>
       )}
       {task.created_on && (
-        <p className="text-xs text-ink-muted mt-3 font-semibold tracking-wide">
+        <p className="text-xs text-ink-muted dark:text-night-faint mt-3 font-semibold tracking-wide">
           {new Date(task.created_on).toLocaleDateString("en-US", {
             month: "short",
             day: "numeric",

--- a/src/components/tasks/TaskForm.tsx
+++ b/src/components/tasks/TaskForm.tsx
@@ -87,15 +87,15 @@ export const TaskForm = ({
   return (
     <div className="min-h-[80vh] flex items-center justify-center p-6">
       <div className="w-full max-w-md">
-        <h2 className="text-xl font-bold text-ink mb-5">
+        <h2 className="text-xl font-bold text-ink dark:text-night-text mb-5">
           {taskId ? "Edit Task" : "New Task"}
         </h2>
-        <div className="bg-white border border-parchment-200 shadow-form rounded-notebook p-6">
+        <div className="bg-white border border-parchment-200 shadow-form rounded-notebook p-6 dark:bg-night-card dark:border-night-border dark:shadow-form-dark">
           <form onSubmit={handleSubmit} className="space-y-5">
             <div>
               <label
                 htmlFor="title"
-                className="block text-sm font-semibold text-ink-light mb-1.5"
+                className="block text-sm font-semibold text-ink-light dark:text-night-muted mb-1.5"
               >
                 Title
               </label>
@@ -111,7 +111,7 @@ export const TaskForm = ({
             <div>
               <label
                 htmlFor="description"
-                className="block text-sm font-semibold text-ink-light mb-1.5"
+                className="block text-sm font-semibold text-ink-light dark:text-night-muted mb-1.5"
               >
                 Description
               </label>
@@ -128,7 +128,7 @@ export const TaskForm = ({
               <button
                 type="submit"
                 disabled={loading}
-                className="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-xl text-white bg-amber-500 hover:bg-amber-600 active:bg-amber-700 shadow-card hover:shadow-card-hover focus:outline-none focus:ring-2 focus:ring-amber-300 disabled:opacity-50 transition-all duration-200"
+                className="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-xl text-white bg-amber-500 hover:bg-amber-600 active:bg-amber-700 shadow-card dark:shadow-card-dark hover:shadow-card-hover dark:hover:shadow-card-dark-hover focus:outline-none focus:ring-2 focus:ring-amber-300 dark:focus:ring-amber-500/30 disabled:opacity-50 transition-all duration-200"
               >
                 <FaSave className="mr-2" />
                 {taskId
@@ -143,7 +143,7 @@ export const TaskForm = ({
                 <button
                   type="button"
                   onClick={() => setOpenConfirm(true)}
-                  className="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-xl text-red-600 bg-red-50 border border-red-200 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-200 transition-all duration-200"
+                  className="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-xl text-red-600 bg-red-50 border border-red-200 hover:bg-red-100 dark:text-red-400 dark:bg-red-500/10 dark:border-red-500/20 dark:hover:bg-red-500/20 focus:outline-none focus:ring-2 focus:ring-red-200 dark:focus:ring-red-500/20 transition-all duration-200"
                 >
                   <FaTrash className="mr-2 text-xs" />
                   Delete
@@ -155,17 +155,17 @@ export const TaskForm = ({
       </div>
 
       {openConfirm && taskId && (
-        <div className="fixed inset-0 bg-ink/40 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-white border border-parchment-200 rounded-notebook p-6 max-w-sm w-full shadow-card-hover">
-            <h3 className="text-lg font-bold text-ink mb-2">Delete task?</h3>
-            <p className="text-sm text-ink-light mb-6">
+        <div className="fixed inset-0 bg-ink/40 dark:bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+          <div className="bg-white border border-parchment-200 rounded-notebook p-6 max-w-sm w-full shadow-card-hover dark:bg-night-card dark:border-night-border dark:shadow-card-dark-hover">
+            <h3 className="text-lg font-bold text-ink dark:text-night-text mb-2">Delete task?</h3>
+            <p className="text-sm text-ink-light dark:text-night-muted mb-6">
               This can&apos;t be undone. The task will be permanently removed.
             </p>
             <div className="flex justify-end gap-3">
               <button
                 type="button"
                 onClick={() => setOpenConfirm(false)}
-                className="px-4 py-2 text-sm font-semibold rounded-xl text-ink-light bg-parchment-100 border border-parchment-300 hover:bg-parchment-200 transition-all duration-200"
+                className="px-4 py-2 text-sm font-semibold rounded-xl text-ink-light bg-parchment-100 border border-parchment-300 hover:bg-parchment-200 dark:text-night-muted dark:bg-night-surface dark:border-night-border dark:hover:bg-night-border transition-all duration-200"
               >
                 Cancel
               </button>

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -8,7 +8,7 @@ interface Props {
 export const TaskList = ({ tasks = [] }: Props) => {
   return (
     <div>
-      <h2 className="text-lg font-bold text-ink mb-5">
+      <h2 className="text-lg font-bold text-ink dark:text-night-text mb-5">
         {tasks.length} {tasks.length === 1 ? "task" : "tasks"}
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
+  darkMode: "class",
   theme: {
     extend: {
       colors: {
@@ -22,12 +23,25 @@ module.exports = {
           muted: "#9c8f84",
           faint: "#c4b8ad",
         },
+        night: {
+          DEFAULT: "#1a1614",
+          surface: "#231f1c",
+          card: "#2a2522",
+          border: "#3d3632",
+          muted: "#78706a",
+          text: "#e8e0d8",
+          faint: "#524b45",
+        },
       },
       boxShadow: {
         card: "0 1px 4px 0 rgba(160, 140, 110, 0.12), 0 1px 2px -1px rgba(160, 140, 110, 0.08)",
         "card-hover":
           "0 6px 16px 0 rgba(160, 140, 110, 0.16), 0 2px 6px -2px rgba(160, 140, 110, 0.1)",
         form: "0 2px 8px 0 rgba(160, 140, 110, 0.1)",
+        "card-dark": "0 1px 4px 0 rgba(0, 0, 0, 0.3), 0 1px 2px -1px rgba(0, 0, 0, 0.2)",
+        "card-dark-hover":
+          "0 6px 16px 0 rgba(0, 0, 0, 0.4), 0 2px 6px -2px rgba(0, 0, 0, 0.25)",
+        "form-dark": "0 2px 8px 0 rgba(0, 0, 0, 0.3)",
       },
       borderRadius: {
         notebook: "14px",


### PR DESCRIPTION
## Summary
- Added class-based dark mode with `ThemeToggle` component (localStorage persistence + system preference detection)
- Created `night` color palette in Tailwind config with dark variants for all UI elements (Navbar, TaskCard, TaskForm, TaskList, modals, toasts)
- Flash-free dark mode via inline script in `<head>`

## E2E Test Results (playwright-cli --headed)
All CRUD operations verified manually in headed browser:
- **Create**: New task created successfully, appeared in task list
- **Read**: Task list displays all tasks with title, description, and date
- **Update**: Task title updated, toast confirmation shown
- **Delete**: Task deleted via confirmation modal, removed from list

## Test plan
- [x] Create a new task and verify it appears in the list
- [x] Read/view existing tasks on the home page
- [x] Update a task title and verify the change persists
- [x] Delete a task via confirmation modal and verify removal
- [ ] Toggle dark mode and verify all components render correctly
- [ ] Verify theme persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)